### PR TITLE
feat: results page refresh

### DIFF
--- a/src/app/games/(not-in-game)/results/[gameId]/page.tsx
+++ b/src/app/games/(not-in-game)/results/[gameId]/page.tsx
@@ -6,6 +6,7 @@ import type { FinalPlayerResult } from "~/lib/games/types"
 import type { Nullable } from "~/lib/utils/types"
 import LeaderboardHighlight from "~/components/leaderboard-screen/LeaderboardHighlight"
 import { LazyLeaderboardWinnerConfetti } from "~/components/leaderboard-screen/LeaderboardWinnerConfetti.lazy"
+import QuestionDifficultyBadge from "~/components/QuestionDifficultyBadge"
 import { ResultsTable } from "~/components/results/ResultsTable"
 import { Badge } from "~/components/ui/badge"
 import { cmp, db, schema } from "~/lib/db"
@@ -35,15 +36,7 @@ async function getResults(gameId: string) {
     notFound()
   }
 
-  const { players, game } = data
-
-  const question = await db.query.questions.findFirst({
-    where: cmp.eq(schema.questions.id, game.question_id),
-  })
-
-  if (!question) {
-    notFound()
-  }
+  const { players, game, question } = data
 
   return {
     players: [...players]
@@ -53,7 +46,7 @@ async function getResults(gameId: string) {
       }))
       .sort((a, b) => a.finalResult.position - b.finalResult.position),
     game,
-    difficulty: question.difficulty,
+    difficulty: question?.difficulty,
   }
 }
 
@@ -76,9 +69,7 @@ export default async function ResultsPage({ params }: { params: { gameId: string
         <h2 className="px-3 py-1 text-center text-sm font-medium opacity-65 sm:text-lg">
           {GAME_MODE_DETAILS[game.mode].description}
         </h2>
-        <Badge variant={MapfromDifficultyToBadgeVariant[difficulty]} className="w-fit text-sm">
-          {`${difficulty[0]!.toLocaleUpperCase()}${difficulty.slice(1)} Question`}
-        </Badge>
+        {difficulty && <QuestionDifficultyBadge difficulty={difficulty} className="text-sm" />}
       </div>
 
       <Suspense>

--- a/src/components/QuestionDifficultyBadge.tsx
+++ b/src/components/QuestionDifficultyBadge.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+
+import { type Doc } from "~/lib/db/types"
+import { MapfromDifficultyToBadgeVariant } from "~/lib/games/types"
+import { cn } from "~/lib/utils"
+import { Badge } from "./ui/badge"
+
+export default function QuestionDifficultyBadge({
+  difficulty,
+  className,
+}: {
+  difficulty: Doc<"questions">["difficulty"]
+  className?: string
+}) {
+  return (
+    <Badge variant={MapfromDifficultyToBadgeVariant[difficulty]} className={cn(className, "w-fit")}>
+      {`${difficulty[0]!.toLocaleUpperCase()}${difficulty.slice(1)} Question`}
+    </Badge>
+  )
+}

--- a/src/components/game-history/GameHistory.tsx
+++ b/src/components/game-history/GameHistory.tsx
@@ -1,12 +1,14 @@
 "use client"
 
 import Link from "next/link"
-import { ArrowRight, Play } from "lucide-react"
+import { ArrowRight, Hash, Play } from "lucide-react"
 
 import type { RouterOutputs } from "~/lib/trpc/react"
 import { GAME_MODE_DETAILS } from "~/lib/games/constants"
+import { MapfromDifficultyToBadgeVariant } from "~/lib/games/types"
 import { api } from "~/lib/trpc/react"
 import { cn } from "~/lib/utils"
+import { Badge } from "../ui/badge"
 import { InfiniteScrollTrigger } from "./InfiniteScrollTrigger"
 
 type GameHistoryPage = RouterOutputs["games"]["getHistory"]
@@ -80,18 +82,22 @@ function GameHistoryItem(props: { item: GameHistoryItem }) {
       className="group/item flex cursor-pointer items-start gap-4 rounded bg-card p-4 transition-colors duration-500 hover:bg-card-lighter hover:duration-75 sm:px-6"
     >
       <span
-        className={cn("grid aspect-square w-8 shrink-0 place-items-center rounded-full", {
-          "bg-primary/70": !isGameFinished || true,
-        })}
+        className={cn(
+          "relative grid aspect-square w-8 shrink-0 place-items-center overflow-hidden rounded-full",
+          {
+            "bg-primary/70": !isGameFinished || true,
+          },
+        )}
       >
         {isGameFinished ? (
           <>{props.item.finalResult?.position ?? <>dnf</>}</>
         ) : (
           <Play className="sq-4" />
         )}
+        <Hash className="absolute -left-2 -top-3 opacity-10 sq-12" />
       </span>
 
-      <span className="flex flex-1 flex-col gap-4">
+      <span className="flex flex-1 flex-col">
         <span className="flex w-full items-end justify-between">
           <span>{GAME_MODE_DETAILS[props.item.mode].title}</span>
 
@@ -100,6 +106,16 @@ function GameHistoryItem(props: { item: GameHistoryItem }) {
             {GAME_MODE_DETAILS[props.item.mode].unitShort}
           </span>
         </span>
+
+        {props.item.difficulty && (
+          <Badge
+            className="mb-2 w-fit text-xs"
+            variant={MapfromDifficultyToBadgeVariant[props.item.difficulty]}
+          >
+            {props.item.difficulty[0]!.toLocaleUpperCase()}
+            {props.item.difficulty.slice(1)} Question
+          </Badge>
+        )}
 
         <span className="flex items-center gap-1 text-sm group-hover/item:underline">
           {linkDetails.label}

--- a/src/components/game-history/GameHistory.tsx
+++ b/src/components/game-history/GameHistory.tsx
@@ -8,6 +8,7 @@ import { GAME_MODE_DETAILS } from "~/lib/games/constants"
 import { MapfromDifficultyToBadgeVariant } from "~/lib/games/types"
 import { api } from "~/lib/trpc/react"
 import { cn } from "~/lib/utils"
+import QuestionDifficultyBadge from "../QuestionDifficultyBadge"
 import { Badge } from "../ui/badge"
 import { InfiniteScrollTrigger } from "./InfiniteScrollTrigger"
 
@@ -108,13 +109,7 @@ function GameHistoryItem(props: { item: GameHistoryItem }) {
         </span>
 
         {props.item.difficulty && (
-          <Badge
-            className="mb-2 w-fit text-xs"
-            variant={MapfromDifficultyToBadgeVariant[props.item.difficulty]}
-          >
-            {props.item.difficulty[0]!.toLocaleUpperCase()}
-            {props.item.difficulty.slice(1)} Question
-          </Badge>
+          <QuestionDifficultyBadge difficulty={props.item.difficulty} className="mb-2 text-xs" />
         )}
 
         <span className="flex items-center gap-1 text-sm group-hover/item:underline">

--- a/src/components/game-screen/QuestionDescription.tsx
+++ b/src/components/game-screen/QuestionDescription.tsx
@@ -4,18 +4,11 @@ import React from "react"
 import { TestTubeDiagonal } from "lucide-react"
 import Markdown from "react-markdown"
 
-import type { BadgeProps } from "~/components/ui/badge"
 import type { GameMode } from "~/lib/games/constants"
 import type { QuestionWithTestCases } from "~/lib/games/types"
 import { Badge } from "~/components/ui/badge"
-import { type Doc } from "~/lib/db/types"
 import { GAME_MODE_DETAILS } from "~/lib/games/constants"
-
-const MapfromDifficultyToBadgeVariant = {
-  easy: "green",
-  medium: "yellow",
-  hard: "red",
-} satisfies Record<Doc<"questions">["difficulty"], NonNullable<BadgeProps["variant"]>>
+import { MapfromDifficultyToBadgeVariant } from "~/lib/games/types"
 
 export default function QuestionDescription(props: {
   question: QuestionWithTestCases

--- a/src/components/leaderboard-screen/LeaderboardHighlight.tsx
+++ b/src/components/leaderboard-screen/LeaderboardHighlight.tsx
@@ -131,10 +131,10 @@ export default function LeaderboardHighlight({
     <div className="my-5 sm:my-10">
       <div
         className={cn(
-          "slide-in minw-full flex min-h-72 flex-col gap-3 sm:grid sm:grid-flow-col-dense sm:grid-cols-3 sm:items-center sm:gap-0",
+          "slide-in flex min-h-72 min-w-full flex-col gap-3 sm:grid sm:grid-flow-col-dense sm:grid-cols-3 sm:items-center sm:gap-0",
         )}
       >
-        <div className="relative z-10 h-full w-full sm:col-start-2">
+        <div className="relative z-10 h-full w-full flex-1 sm:col-start-2">
           <div className="h-full sm:scale-110">
             <PlayerCard
               player={players[0]}

--- a/src/lib/games/queries.ts
+++ b/src/lib/games/queries.ts
@@ -229,9 +229,14 @@ export async function getGameResultsData(tx: DBOrTransation, gameId: string) {
     },
   })
 
+  const question = await tx.query.questions.findFirst({
+    where: cmp.eq(schema.questions.id, game.question_id),
+  })
+
   return {
     players: playerGameSessions,
-    game: game,
+    game,
+    question,
   }
 }
 

--- a/src/lib/games/queries.ts
+++ b/src/lib/games/queries.ts
@@ -47,6 +47,9 @@ export async function getUserGameHistory(
         position: schema.playerGameSessionFinalResults.position,
         score: schema.playerGameSessionFinalResults.score,
       },
+      question: {
+        difficulty: schema.questions.difficulty,
+      },
     })
     .from(schema.playerGameSessions)
     .where(filter)
@@ -58,6 +61,7 @@ export async function getUserGameHistory(
         schema.playerGameSessionFinalResults.player_game_session_id,
       ),
     )
+    .leftJoin(schema.questions, cmp.eq(schema.gameStates.question_id, schema.questions.id))
     .orderBy(orderBy.desc(schema.gameStates.inserted_at))
     .limit(limit)
 
@@ -65,6 +69,7 @@ export async function getUserGameHistory(
     items: results.map((item) => {
       return {
         ...item.game,
+        difficulty: item.question?.difficulty,
         finalResult: item.finalResult,
       }
     }),

--- a/src/lib/games/types.ts
+++ b/src/lib/games/types.ts
@@ -1,3 +1,4 @@
+import { type BadgeProps } from "~/components/ui/badge"
 import { type Doc } from "../db/types"
 import { type getSessionInfoForPlayer } from "./queries"
 
@@ -24,3 +25,9 @@ export type QuestionWithTestCases = FullGameState["question"]
 export type PlayerGameSession = NonNullable<Awaited<ReturnType<typeof getSessionInfoForPlayer>>>
 
 export type FinalPlayerResult = Pick<Doc<"playerGameSessionFinalResults">, "position" | "score">
+
+export const MapfromDifficultyToBadgeVariant = {
+  easy: "green",
+  medium: "yellow",
+  hard: "red",
+} satisfies Record<Doc<"questions">["difficulty"], NonNullable<BadgeProps["variant"]>>


### PR DESCRIPTION
This adds: 
- win cond to results page
- question difficulty
- adds difficulty to the cards in the game history page

| Results                                                                                           | History                                                                                           |
|---------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
| ![image 1](https://github.com/user-attachments/assets/11e547b7-bb40-4f06-8995-3ec61e796c2b)       | ![image 2](https://github.com/user-attachments/assets/93a8ee30-174c-4343-a55c-106e0f8560f7)       |