### PR TITLE
events system

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "turboConsoleLog.delimiterInsideMessage": "!!",
   "cSpell.words": [
+    "contravariance",
     "dequal",
     "formkit",
     "inngest",

--- a/src/lib/auth/profile.ts
+++ b/src/lib/auth/profile.ts
@@ -1,5 +1,6 @@
 import { cache } from "react"
 import { type User } from "@supabase/supabase-js"
+import { TRPCError } from "@trpc/server"
 import { isAfter, subSeconds } from "date-fns"
 
 import { cmp, db, schema } from "../db"
@@ -55,6 +56,19 @@ export async function upsertProfile(authUser: User) {
       provider: "github",
     })
   }
+}
+
+export async function requireUserProfile(userId: string) {
+  const profile = await getUserProfile(userId)
+
+  if (!profile) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "You must be logged in to access this resource",
+    })
+  }
+
+  return profile
 }
 
 async function getUserProfileImpl(userId: string) {

--- a/src/lib/games/events/client.ts
+++ b/src/lib/games/events/client.ts
@@ -1,0 +1,47 @@
+import { useEffect } from "react"
+import { type SupabaseClient } from "@supabase/supabase-js"
+
+import { type Doc } from "~/lib/db/types"
+import { useStableCallback } from "~/lib/utils/use-stable-callback"
+import { type GameEvent } from "./schema"
+
+export function useHandleGameEvent(props: {
+  supabase: SupabaseClient
+  gameId: string
+  handleEvent: (event: GameEvent) => void
+}) {
+  const stableHandleEvent = useStableCallback(props.handleEvent)
+
+  useEffect(() => {
+    // TODO: should this be handled by the consumer?
+    let safe = true
+
+    const gameStateChannel = props.supabase
+      .channel("gameEvents")
+      .on<Doc<"gameEvents">>(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "game_events",
+          filter: `game_id=eq.${props.gameId}`,
+        },
+        (payload) => {
+          if (!safe) return
+
+          console.log(payload)
+
+          stableHandleEvent(payload.new.payload)
+        },
+      )
+      .subscribe()
+
+    return () => {
+      void gameStateChannel.unsubscribe()
+      void props.supabase
+        .removeChannel(gameStateChannel)
+        .catch((e) => console.error("failed to remove channel", e))
+      safe = false
+    }
+  }, [props.gameId, props.supabase, stableHandleEvent])
+}

--- a/src/lib/games/events/schema.ts
+++ b/src/lib/games/events/schema.ts
@@ -24,4 +24,5 @@ export const gameEventSchema = z.discriminatedUnion("type", [
     }),
   ),
 ])
+
 export type GameEvent = z.infer<typeof gameEventSchema>

--- a/src/lib/games/events/schema.ts
+++ b/src/lib/games/events/schema.ts
@@ -12,6 +12,16 @@ function defineEventSchema<Type extends string, Schema extends ZodObject<ZodRawS
 }
 
 export const gameEventSchema = z.discriminatedUnion("type", [
-  defineEventSchema("test", z.object({})),
+  defineEventSchema(
+    "player-joined",
+    z.object({
+      player: z.object({
+        id: z.string(),
+        name: z.string(),
+        profile_image_url: z.string().nullable(),
+        wins: z.number(),
+      }),
+    }),
+  ),
 ])
 export type GameEvent = z.infer<typeof gameEventSchema>

--- a/src/lib/games/events/schema.ts
+++ b/src/lib/games/events/schema.ts
@@ -1,0 +1,17 @@
+import type { ZodObject, ZodRawShape } from "zod"
+import { z } from "zod"
+
+function defineEventSchema<Type extends string, Schema extends ZodObject<ZodRawShape>>(
+  type: Type,
+  schema: Schema,
+) {
+  return z.object({
+    type: z.literal(type),
+    data: schema,
+  })
+}
+
+export const gameEventSchema = z.discriminatedUnion("type", [
+  defineEventSchema("test", z.object({})),
+])
+export type GameEvent = z.infer<typeof gameEventSchema>

--- a/src/lib/games/events/server.ts
+++ b/src/lib/games/events/server.ts
@@ -4,13 +4,15 @@ import { schema } from "~/lib/db"
 import { type DBOrTransation } from "~/lib/db/types"
 import { type GameEvent } from "./schema"
 
+const ALL_USERS: unique symbol = Symbol("push-event:all-users")
 export async function pushEvent(
   db: DBOrTransation,
-  args: { gameId: string; event: GameEvent; userId: string | null },
+  args: { gameId: string; event: GameEvent; userId: string | typeof ALL_USERS },
 ) {
   await db.insert(schema.gameEvents).values({
     game_id: args.gameId,
     payload: args.event,
-    user_id: args.userId,
+    user_id: args.userId === ALL_USERS ? null : args.userId,
   })
 }
+pushEvent.ALL_USERS = ALL_USERS

--- a/src/lib/games/events/server.ts
+++ b/src/lib/games/events/server.ts
@@ -7,7 +7,7 @@ import { type DBOrTransaction } from "~/lib/db/types"
 import { type GameEvent } from "./schema"
 
 const ALL_USERS: unique symbol = Symbol("push-event:all-users")
-export async function pushEvent(
+export async function pushGameEvent(
   db: DBOrTransaction,
   args: { gameId: string; event: GameEvent; userId: string | typeof ALL_USERS },
 ) {
@@ -17,7 +17,7 @@ export async function pushEvent(
     user_id: args.userId === ALL_USERS ? null : args.userId,
   })
 }
-pushEvent.ALL_USERS = ALL_USERS
+pushGameEvent.ALL_USERS = ALL_USERS
 
 export async function deleteOldGameEvents(db: DBOrTransaction) {
   const oneWeekAgo = subWeeks(new Date(), 1)

--- a/src/lib/games/events/server.ts
+++ b/src/lib/games/events/server.ts
@@ -1,0 +1,16 @@
+import "server-only"
+
+import { schema } from "~/lib/db"
+import { type DBOrTransation } from "~/lib/db/types"
+import { type GameEvent } from "./schema"
+
+export async function pushEvent(
+  db: DBOrTransation,
+  args: { gameId: string; event: GameEvent; userId: string | null },
+) {
+  await db.insert(schema.gameEvents).values({
+    game_id: args.gameId,
+    payload: args.event,
+    user_id: args.userId,
+  })
+}

--- a/src/lib/games/trpc.ts
+++ b/src/lib/games/trpc.ts
@@ -366,10 +366,6 @@ export const gameRouter = createTRPCRouter({
         return { game }
       })
 
-      // Update gameState to trigger real-time updates for all connected clients when
-      // players join/leave the lobby
-      await touchGameState(game.id)
-
       return {
         game_id: game.id,
         mode: game.mode,

--- a/src/lib/games/trpc.ts
+++ b/src/lib/games/trpc.ts
@@ -30,7 +30,8 @@ import { getQuestionTestCasesOrderBy, getRandomGameMode } from "~/lib/games/util
 import { logger } from "~/lib/server/logger"
 import { createTRPCRouter, protectedProcedure } from "~/lib/trpc/trpc"
 import { randomElement } from "~/lib/utils/random"
-import { getUserProfile } from "../auth/profile"
+import { getUserProfile, requireUserProfile } from "../auth/profile"
+import { pushGameEvent } from "./events/server"
 import { getPlayerPositionsForGameMode } from "./game-modes"
 import { cancelInngestGameWorkflow, finalizeGame, touchGameState } from "./internal-actions"
 
@@ -327,19 +328,42 @@ export const gameRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const currentGame = await getLatestActiveGameForUser(ctx.db, ctx.user.id)
+      const [currentGame, profile] = await Promise.all([
+        getLatestActiveGameForUser(ctx.db, ctx.user.id),
+        requireUserProfile(ctx.user.id),
+      ])
 
       if (currentGame) {
         throw new Error("You are already in a game")
       }
 
-      const { game, question } = await getOrCreateGameToJoin(ctx.db, ctx.inngest, input.difficulty)
+      const { game } = await ctx.db.transaction(async (tx) => {
+        const { game, question } = await getOrCreateGameToJoin(tx, ctx.inngest, input.difficulty)
 
-      await ctx.db.insert(schema.playerGameSessions).values({
-        user_id: ctx.user.id,
-        game_id: game.id,
-        code: question.starterCode,
-        model: "openai::gpt-4o-mini",
+        await tx.insert(schema.playerGameSessions).values({
+          user_id: ctx.user.id,
+          game_id: game.id,
+          code: question.starterCode,
+          model: "openai::gpt-4o-mini",
+        })
+
+        await pushGameEvent(tx, {
+          gameId: game.id,
+          userId: pushGameEvent.ALL_USERS,
+          event: {
+            type: "player-joined",
+            data: {
+              player: {
+                id: ctx.user.id,
+                name: profile.name,
+                profile_image_url: profile.profile_image_url,
+                wins: profile.wins,
+              },
+            },
+          },
+        })
+
+        return { game }
       })
 
       // Update gameState to trigger real-time updates for all connected clients when

--- a/src/lib/games/types.ts
+++ b/src/lib/games/types.ts
@@ -2,12 +2,12 @@ import { type BadgeProps } from "~/components/ui/badge"
 import { type Doc } from "../db/types"
 import { type getSessionInfoForPlayer } from "./queries"
 
-type FullGameState = Doc<"gameStates"> & {
+type FullGameState = Omit<Doc<"gameStates">, "question_id"> & {
   question: Doc<"questions"> & {
     testCases: Doc<"questionTestCases">[]
   }
   players: {
-    user: Doc<"userProfiles">
+    user: Pick<Doc<"userProfiles">, "id" | "name" | "profile_image_url" | "wins">
   }[]
 }
 
@@ -31,3 +31,8 @@ export const DifficultyToBadgeVariantMap = {
   medium: "yellow",
   hard: "red",
 } satisfies Record<Doc<"questions">["difficulty"], NonNullable<BadgeProps["variant"]>>
+
+export type ClientGameState = {
+  gameState: InGameState
+  gameSession: PlayerGameSession
+}

--- a/src/lib/inngest/functions/cleanup-game-events.ts
+++ b/src/lib/inngest/functions/cleanup-game-events.ts
@@ -1,0 +1,19 @@
+import { db } from "~/lib/db"
+import { deleteOldGameEvents } from "~/lib/games/events/server"
+import { inngest } from "~/lib/inngest/client"
+
+export const cleanupGameEventsFunction = inngest.createFunction(
+  {
+    id: "cleanup-game-events",
+  },
+
+  {
+    cron: "0 0 * * 0",
+  },
+
+  async ({ step }) => {
+    await step.run("delete-game-events", async () => {
+      await deleteOldGameEvents(db)
+    })
+  },
+)

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -1,3 +1,8 @@
 export type Nullable<T> = T | null | undefined
 
 export type Values<T> = T[keyof T]
+
+// This is required due to ✨ contravariance ✨ :)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Unsafe_AnyFunctionParameters = any[]
+export type Unsafe_AnyFunction = (...args: Unsafe_AnyFunctionParameters) => unknown

--- a/src/lib/utils/use-stable-callback.ts
+++ b/src/lib/utils/use-stable-callback.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react"
+import { useCallback, useLayoutEffect, useRef } from "react"
 
 import { type Unsafe_AnyFunction } from "./types"
 
@@ -12,7 +12,7 @@ export function useStableCallback<T extends Unsafe_AnyFunction>(callback?: T) {
 
   const callbackRef = useRef(callback)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     callbackRef.current = callback
   })
 

--- a/src/lib/utils/use-stable-callback.ts
+++ b/src/lib/utils/use-stable-callback.ts
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useRef } from "react"
 
-export function useStableCallback<T extends (...args: unknown[]) => unknown>(callback: T): T
-export function useStableCallback<T extends (...args: unknown[]) => unknown>(
+import { type Unsafe_AnyFunction } from "./types"
+
+export function useStableCallback<T extends Unsafe_AnyFunction>(callback: T): T
+export function useStableCallback<T extends Unsafe_AnyFunction>(
   callback?: T | undefined,
 ): (...args: Parameters<T>) => ReturnType<T> | undefined
-export function useStableCallback<T extends (...args: unknown[]) => unknown>(callback?: T) {
+export function useStableCallback<T extends Unsafe_AnyFunction>(callback?: T) {
   type Args = Parameters<T>
   type Result = ReturnType<T> | undefined
 


### PR DESCRIPTION
add events system to replace current "realtime" setup

current realtime setup is a bit dodgy - we notify the client when relevant data has updated, and then refetch the data in a separate request from the client. this was required as some queries involved joins, and you can't subscribe to "join"-ed queries with supabase's realtime. that was good enough to get the game to work, but makes the game feel a bit janky, and slower to respond than is ideal.

the events system will allow us to easily send fat events containing the updated data for the client. for now, it is built on top of a postgres table that we listen to w/ supabase's realtime, but should be relatively easily swappable for our own or a 3rd party websocket service. for now, i've pushed & handle messages for joining games as a POC, but should be easy to add new events & remove the old realtime-ish setup.

old events (>1 week old) will be deleted. picked 1 week so we have a chance to debug issues

Ref: CHA-185