### PR TITLE
feat: implement picture question components and update config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,16 @@ const config = {
     ppr: true,
   },
 
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "mpwnskdajkinivskolsr.supabase.co",
+        pathname: "/storage/v1/object/public/picture-question-images/**",
+      },
+    ],
+  },
+
   async rewrites() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "geist": "^1.3.0",
     "hast-util-to-jsx-runtime": "^2.3.0",
     "inngest": "^3.22.1",
+    "isomorphic-dompurify": "^2.23.0",
     "js-confetti": "^0.12.0",
     "lucide-react": "^0.417.0",
     "ms": "^2.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ dependencies:
   inngest:
     specifier: ^3.22.1
     version: 3.22.1(next@15.0.0-canary.161)(typescript@5.5.4)
+  isomorphic-dompurify:
+    specifier: ^2.23.0
+    version: 2.23.0
   js-confetti:
     specifier: ^0.12.0
     version: 0.12.0
@@ -389,6 +392,16 @@ packages:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
+  /@asamuzakjp/css-color@3.1.2:
+    resolution: {integrity: sha512-nwgc7jPn3LpZ4JWsoHtuwBsad1qSSLDDX634DdG0PBJofIuIEtSWk4KkRmuXyu178tjuHAbwiMNNzwqIyLYxZw==}
+    dependencies:
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-color-parser': 3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+      lru-cache: 10.4.3
+    dev: false
+
   /@babel/code-frame@7.24.7:
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
     engines: {node: '>=6.9.0'}
@@ -537,6 +550,49 @@ packages:
       '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
+
+  /@csstools/color-helpers@5.0.2:
+    resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
+    engines: {node: '>=18'}
+    dev: false
+
+  /@csstools/css-calc@2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3):
+    resolution: {integrity: sha512-TklMyb3uBB28b5uQdxjReG4L80NxAqgrECqLZFQbyLekwwlcDDS8r3f07DKqeo8C4926Br0gf/ZDe17Zv4wIuw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.4
+      '@csstools/css-tokenizer': ^3.0.3
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+    dev: false
+
+  /@csstools/css-color-parser@3.0.8(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3):
+    resolution: {integrity: sha512-pdwotQjCCnRPuNi06jFuP68cykU1f3ZWExLe/8MQ1LOs8Xq+fTkYgd+2V8mWUWMrOn9iS2HftPVaMZDaXzGbhQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.4
+      '@csstools/css-tokenizer': ^3.0.3
+    dependencies:
+      '@csstools/color-helpers': 5.0.2
+      '@csstools/css-calc': 2.1.2(@csstools/css-parser-algorithms@3.0.4)(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
+      '@csstools/css-tokenizer': 3.0.3
+    dev: false
+
+  /@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3):
+    resolution: {integrity: sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.3
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.3
+    dev: false
+
+  /@csstools/css-tokenizer@3.0.3:
+    resolution: {integrity: sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==}
+    engines: {node: '>=18'}
+    dev: false
 
   /@drizzle-team/brocli@0.10.2:
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -2654,6 +2710,12 @@ packages:
       '@types/prismjs': 1.26.4
     dev: true
 
+  /@types/trusted-types@2.0.7:
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@types/unist@2.0.10:
     resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
     dev: false
@@ -2955,6 +3017,11 @@ packages:
     resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  /agent-base@7.1.3:
+    resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
+    engines: {node: '>= 14'}
+    dev: false
 
   /ai@3.3.0(react@19.0.0-rc-e4953922-20240919)(svelte@4.2.18)(vue@3.4.35)(zod@3.23.8):
     resolution: {integrity: sha512-ndW4G9jw8ImIsTWK2iderOWMVn4H3B6u+KHlZ7hJEvFBdBYTFQ62qTw10AmHsQefjwHRC/2evr9qf79EkSwo9Q==}
@@ -3488,12 +3555,28 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  /cssstyle@4.3.0:
+    resolution: {integrity: sha512-6r0NiY0xizYqfBvWp1G7WXJ06/bZyrk7Dc6PHql82C/pKGUTKu4yAX4Y8JPamb1ob9nBKuxWzCGTRuGwU3yxJQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@asamuzakjp/css-color': 3.1.2
+      rrweb-cssom: 0.8.0
+    dev: false
+
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
     dev: true
+
+  /data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+    dev: false
 
   /data-view-buffer@1.0.1:
     resolution: {integrity: sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==}
@@ -3551,6 +3634,10 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+
+  /decimal.js@10.5.0:
+    resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
+    dev: false
 
   /decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -3661,6 +3748,12 @@ packages:
     dependencies:
       esutils: 2.0.3
     dev: true
+
+  /dompurify@3.2.5:
+    resolution: {integrity: sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==}
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+    dev: false
 
   /dotenv-cli@7.4.2:
     resolution: {integrity: sha512-SbUj8l61zIbzyhIbg0FwPJq6+wjbzdn9oEtozQpZ6kW2ihCcapKVZj49oCT3oPM+mgQm+itgvUQcG5szxVrZTA==}
@@ -4765,8 +4858,42 @@ packages:
       space-separated-tokens: 2.0.2
     dev: false
 
+  /html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      whatwg-encoding: 3.1.1
+    dev: false
+
   /html-url-attributes@3.0.0:
     resolution: {integrity: sha512-/sXbVCWayk6GDVg3ctOX6nxaVj7So40FcFAnWlWGNAB1LpYKcV5Cd10APjPjW80O7zYW2MsjBV4zZ7IZO5fVow==}
+    dev: false
+
+  /http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.3.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.3
+      debug: 4.3.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
     dev: false
 
   /ieee754@1.2.1:
@@ -5026,6 +5153,10 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+    dev: false
+
   /is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
     dependencies:
@@ -5104,6 +5235,19 @@ packages:
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  /isomorphic-dompurify@2.23.0:
+    resolution: {integrity: sha512-f9w5fPJwlu+VK1uowFy4eWYgd7uxl0nQJbtorGp1OAs6JeY1qPkBQKNee1RXrnr68GqZ86PwQ6LF/5rW1TrOZQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      dompurify: 3.2.5
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+    dev: false
+
   /iterator.prototype@1.1.2:
     resolution: {integrity: sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==}
     dependencies:
@@ -5147,6 +5291,41 @@ packages:
     dependencies:
       argparse: 2.0.1
     dev: true
+
+  /jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      cssstyle: 4.3.0
+      data-urls: 5.0.0
+      decimal.js: 10.5.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.20
+      parse5: 7.2.1
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
 
   /jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -5761,6 +5940,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  /nwsapi@2.2.20:
+    resolution: {integrity: sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==}
+    dev: false
+
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -5892,6 +6075,12 @@ packages:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+    dev: false
+
+  /parse5@7.2.1:
+    resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
+    dependencies:
+      entities: 4.5.0
     dev: false
 
   /path-exists@4.0.0:
@@ -6265,7 +6454,6 @@ packages:
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-    dev: true
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -6556,6 +6744,10 @@ packages:
       glob: 7.2.3
     dev: true
 
+  /rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+    dev: false
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -6591,6 +6783,17 @@ packages:
   /safe-stable-stringify@2.4.3:
     resolution: {integrity: sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==}
     engines: {node: '>=10'}
+    dev: false
+
+  /safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: false
+
+  /saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+    dependencies:
+      xmlchars: 2.2.0
     dev: false
 
   /scheduler@0.25.0-rc-e4953922-20240919:
@@ -6989,6 +7192,10 @@ packages:
       vue: 3.4.35(typescript@5.5.4)
     dev: false
 
+  /symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+    dev: false
+
   /tailwind-merge@2.4.0:
     resolution: {integrity: sha512-49AwoOQNKdqKPd9CViyH5wJoSKsCDjUlzL8DxuGp3P1FsGY36NJDAa18jLZcaHAUUuTj+JB8IAo8zWgBNvBF7A==}
     dev: false
@@ -7057,6 +7264,17 @@ packages:
       real-require: 0.2.0
     dev: false
 
+  /tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+    dev: false
+
+  /tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+    dependencies:
+      tldts-core: 6.1.86
+    dev: false
+
   /to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -7067,8 +7285,22 @@ packages:
     dependencies:
       is-number: 7.0.0
 
+  /tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+    dependencies:
+      tldts: 6.1.86
+    dev: false
+
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: false
+
+  /tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+    dependencies:
+      punycode: 2.3.1
     dev: false
 
   /trim-lines@3.0.1:
@@ -7347,12 +7579,44 @@ packages:
       typescript: 5.5.4
     dev: false
 
+  /w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+    dependencies:
+      xml-name-validator: 5.0.0
+    dev: false
+
   /web-vitals@4.2.3:
     resolution: {integrity: sha512-/CFAm1mNxSmOj6i0Co+iGFJ58OS4NRGVP+AWS/l509uIK5a1bSoIVaHz/ZumpHTfHSZBpgrJ+wjfpAOrTHok5Q==}
     dev: false
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: false
+
+  /webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      iconv-lite: 0.6.3
+    dev: false
+
+  /whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+    dev: false
+
+  /whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
     dev: false
 
   /whatwg-url@5.0.0:
@@ -7454,6 +7718,15 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: false
+
+  /xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+    dev: false
+
+  /xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
     dev: false
 
   /xtend@4.0.2:

--- a/src/components/game-screen/CodeView.tsx
+++ b/src/components/game-screen/CodeView.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react"
 import { Send } from "lucide-react"
 
 import { MAX_SEND_MESSAGE_CHARACTER_LIMIT } from "~/lib/games/constants"
+import { getQuestionType } from "~/lib/games/question-types/base"
 import CodeRenderer from "../CodeRenderer"
 import { Button } from "../ui/button"
 import { Input } from "../ui/input"
@@ -25,7 +26,9 @@ export default function CodeView() {
     <>
       <CodeRenderer
         code={context.gameSessionInfo.code}
-        language="python"
+        language={
+          getQuestionType(context.gameSessionInfo.game.question) === "picture" ? "html" : "python"
+        }
         preProps={{ className: "py-0 sm:py-2 mb-4" }}
         codeProps={{ className: "pr-0 p-2 sm:p-0" }}
         showLineNumbers={!context.isMobile}

--- a/src/components/game-screen/picture/PictureQuestionDescription.tsx
+++ b/src/components/game-screen/picture/PictureQuestionDescription.tsx
@@ -1,0 +1,38 @@
+import Image from "next/image"
+import Markdown from "react-markdown"
+
+import type { PictureQuestion } from "~/lib/games/types"
+import { useGameManager } from "~/components/game-screen/GameManagerProvider"
+import { Badge } from "~/components/ui/badge"
+import { WinConditionCard } from "~/components/WinConditionCard"
+import { GAME_MODE_DETAILS } from "~/lib/games/constants"
+import { PICTURE_QUESTION_DIFFICULTY_CONFIGS } from "~/lib/games/question-types/picture/constants"
+import { DifficultyToBadgeVariantMap } from "~/lib/games/types"
+
+export function PictureQuestionDescription({ question }: { question: PictureQuestion }) {
+  const { gameInfo } = useGameManager()
+
+  return (
+    <div>
+      <div className="mb-1 text-2xl font-bold">Picture Question</div>
+      <Badge variant={DifficultyToBadgeVariantMap[question.difficulty]} className="mb-2">
+        {question.difficulty}
+      </Badge>
+      <WinConditionCard mode={GAME_MODE_DETAILS[gameInfo.mode]} />
+      <div className="text-pretty text-sm">
+        <Markdown className="prose prose-invert">{question.pictureQuestion.description}</Markdown>
+      </div>
+
+      <div className="mt-8">
+        <h3 className="mb-2 font-medium">Solution Image</h3>
+        <Image
+          src={question.pictureQuestion.solution_image_url}
+          width={PICTURE_QUESTION_DIFFICULTY_CONFIGS[question.difficulty].size}
+          height={PICTURE_QUESTION_DIFFICULTY_CONFIGS[question.difficulty].size}
+          alt="Solution"
+          className="max-w-full rounded-md"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/game-screen/picture/PictureQuestionResults.tsx
+++ b/src/components/game-screen/picture/PictureQuestionResults.tsx
@@ -1,12 +1,42 @@
+import DOMPurify from "isomorphic-dompurify"
+
 import { Skeleton } from "~/components/ui/skeleton"
 import { PICTURE_QUESTION_DIFFICULTY_CONFIGS } from "~/lib/games/question-types/picture/constants"
 import { useGameManager } from "../GameManagerProvider"
 
 const HTMLPreview = ({ html, size }: { html: string; size: number }) => {
+  const sanitizedHtml = DOMPurify.sanitize(html, {
+    FORBID_TAGS: [
+      "script",
+      "iframe",
+      "frame",
+      "object",
+      "embed",
+      "img",
+      "video",
+      "audio",
+      "source",
+      "picture",
+      "track",
+    ],
+    FORBID_ATTR: [
+      "onerror",
+      "onload",
+      "onclick",
+      "onmouseover",
+      "onmouseout",
+      "href",
+      "src",
+      "srcset",
+      "data-src",
+    ],
+    FORCE_BODY: true,
+  })
+
   return (
     <iframe
-      key={html}
-      srcDoc={html}
+      key={sanitizedHtml}
+      srcDoc={sanitizedHtml}
       style={{
         width: size,
         height: size,

--- a/src/components/game-screen/picture/PictureQuestionResults.tsx
+++ b/src/components/game-screen/picture/PictureQuestionResults.tsx
@@ -1,0 +1,44 @@
+import { Skeleton } from "~/components/ui/skeleton"
+import { PICTURE_QUESTION_DIFFICULTY_CONFIGS } from "~/lib/games/question-types/picture/constants"
+import { useGameManager } from "../GameManagerProvider"
+
+const HTMLPreview = ({ html, size }: { html: string; size: number }) => {
+  return (
+    <iframe
+      key={html}
+      srcDoc={html}
+      style={{
+        width: size,
+        height: size,
+      }}
+      className="rounded-lg border border-border bg-white"
+      title="HTML Preview"
+      sandbox="allow-scripts"
+    />
+  )
+}
+
+export function PictureQuestionResults() {
+  const { gameSessionInfo, isGeneratingCode } = useGameManager()
+  const { size } = PICTURE_QUESTION_DIFFICULTY_CONFIGS[gameSessionInfo.game.question.difficulty]
+
+  return (
+    <div className="relative flex flex-col">
+      <div className="flex-1">
+        {gameSessionInfo.code ? (
+          <>
+            {!isGeneratingCode ? (
+              <HTMLPreview html={gameSessionInfo.code} size={size} />
+            ) : (
+              <Skeleton style={{ width: size, height: size }} />
+            )}
+          </>
+        ) : (
+          <div className="rounded-lg border border-border p-4 text-sm text-muted-foreground">
+            No preview available yet. Submit your code to see the result.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/games/internal-actions.ts
+++ b/src/lib/games/internal-actions.ts
@@ -12,6 +12,7 @@ import { captureUserEvent } from "../posthog/server"
 import { LLM_PROMPTING_TIMEOUT } from "./constants"
 import { getPlayerPositionsForGameMode } from "./game-modes"
 import { getGameById } from "./queries"
+import { getQuestionType } from "./question-types/base"
 import { chatHistoryItemTypeIs } from "./utils"
 
 export async function advanceGameToStatus(
@@ -130,7 +131,11 @@ export async function sendMessageInGame(gameId: string, instructions: string) {
       cmp.eq(schema.playerGameSessions.game_id, gameId),
     ),
     with: {
-      game: true,
+      game: {
+        with: {
+          question: true,
+        },
+      },
     },
   })
 
@@ -197,6 +202,7 @@ export async function sendMessageInGame(gameId: string, instructions: string) {
     .where(cmp.eq(schema.playerGameSessions.id, playerGameSession.id))
 
   const result = await streamUpdatedCode({
+    questionType: getQuestionType(playerGameSession.game.question),
     existingCode: playerGameSession.code,
     instructions,
     modelId: playerGameSession.model,

--- a/src/lib/games/question-types/picture/client.tsx
+++ b/src/lib/games/question-types/picture/client.tsx
@@ -2,6 +2,8 @@ import { invariant } from "@epic-web/invariant"
 
 import type { FullQuestion } from "../../types"
 import type { ClientQuestionStrategy } from "../base"
+import { PictureQuestionDescription } from "~/components/game-screen/picture/PictureQuestionDescription"
+import { PictureQuestionResults } from "~/components/game-screen/picture/PictureQuestionResults"
 import { BaseQuestionStrategy } from "../base"
 import { PictureQuestionConfig } from "./config"
 
@@ -20,12 +22,10 @@ export class PictureQuestionStrategy
   }
 
   descriptionPanel() {
-    throw new Error("Not implemented")
-    return { content: <></> }
+    return { content: <PictureQuestionDescription question={this.question} /> }
   }
 
   resultsPanel() {
-    throw new Error("Not implemented")
-    return { content: <></>, footer: <></> }
+    return { content: <PictureQuestionResults />, footer: <></> }
   }
 }

--- a/src/lib/llm/generation.ts
+++ b/src/lib/llm/generation.ts
@@ -6,6 +6,7 @@ import { invariant } from "@epic-web/invariant"
 import { streamText } from "ai"
 
 import { env } from "~/env"
+import { QuestionType } from "../games/constants"
 import { type ModelId } from "./constants"
 import { parseModelId } from "./utils"
 
@@ -34,24 +35,27 @@ export async function streamUpdatedCode(args: {
   existingCode: string
   instructions: string
   modelId: ModelId
+  questionType: QuestionType
   onFinish?: Parameters<typeof streamText>[0]["onFinish"]
 }) {
-  const stream = await streamText({
-    model: getAIModelProvider(args.modelId),
-    temperature: 0.7,
-    stopSequences: ["</code>"],
-    messages: [
-      {
-        role: "system",
-        content: [
+  const systemPrompt =
+    args.questionType === "programming"
+      ? [
           "You are a terse, helpful AI assistant that helps people write code.",
           "You should only ever output code wrapped in a <code> tag.",
           "Never update the existing function's name or argument list.",
-        ].join(" "),
-      },
-      {
-        role: "user",
-        content: `
+        ].join(" ")
+      : [
+          "You are a terse, helpful AI assistant that creates images using HTML and CSS.",
+          "You should only ever output code wrapped in a <code> tag.",
+          "Your code must consist of a <style> section and HTML elements.",
+          "Use only HTML and CSS to create visual designs - no JavaScript.",
+          "Focus on geometric shapes, colors, and positioning to create the requested image.",
+        ].join(" ")
+
+  const userPrompt =
+    args.questionType === "programming"
+      ? `
 CURRENT CODE: <code>
 ${args.existingCode}
 </code>
@@ -64,7 +68,35 @@ Follow the instructions to update the provided python code. Output only the upda
 The update code should contain a function named "solution", and the arguments should be the same as the current code.
 
 UPDATED CODE:
-`.trim(),
+`.trim()
+      : `
+CURRENT CODE: <code>
+${args.existingCode}
+</code>
+
+INSTRUCTIONS: <instructions>
+${args.instructions}
+</instructions>
+
+Create an image using only HTML and CSS based on the instructions. Output only the code wrapped in a <code> tag.
+Your code should include both the HTML structure and CSS styles needed to create the image.
+Keep the code minimal and efficient.
+
+UPDATED CODE:
+`.trim()
+
+  const stream = await streamText({
+    model: getAIModelProvider(args.modelId),
+    temperature: 0.7,
+    stopSequences: ["</code>"],
+    messages: [
+      {
+        role: "system",
+        content: systemPrompt,
+      },
+      {
+        role: "user",
+        content: userPrompt,
       },
     ],
     onFinish: args.onFinish,


### PR DESCRIPTION
- Added PictureQuestionDescription and PictureQuestionResults components for displaying picture questions and their results.
- Updated next.config.js to allow images from Supabase.
- Modified the PictureQuestionStrategy to use the new components for description and results panels.
- Updated LLM generation logic to handle HTML/CSS question types.
- Added isomorphic-dompurify to sanitize HTML content in PictureQuestionResults

https://github.com/user-attachments/assets/e4dc7831-0b08-4407-abc4-032b9411cfb2
